### PR TITLE
Closing HTTP response bodies

### DIFF
--- a/annotation_event.go
+++ b/annotation_event.go
@@ -75,6 +75,12 @@ func (sdc *StackdriverClient) NewAnnotationEvent(m, ab, l, iid string, ee int64)
 	req.Header.Add("x-stackdriver-apikey", sdc.ApiKey)
 
 	res, err := client.Do(req)
+
+	// Close here to protect against redirection failures where both res and err may be non-nil.
+	if res != nil {
+		defer res.Body.Close()
+	}
+
 	if err != nil {
 		return err
 	}

--- a/annotation_event.go
+++ b/annotation_event.go
@@ -75,15 +75,10 @@ func (sdc *StackdriverClient) NewAnnotationEvent(m, ab, l, iid string, ee int64)
 	req.Header.Add("x-stackdriver-apikey", sdc.ApiKey)
 
 	res, err := client.Do(req)
-
-	// Close here to protect against redirection failures where both res and err may be non-nil.
-	if res != nil {
-		defer res.Body.Close()
-	}
-
 	if err != nil {
 		return err
 	}
+	defer res.Body.Close()
 
 	if (res.StatusCode > 200) || (res.StatusCode < 200) {
 		responseBody, err := ioutil.ReadAll(res.Body)

--- a/custom_metric.go
+++ b/custom_metric.go
@@ -86,15 +86,10 @@ func (sdc *StackdriverClient) Send(gwm GatewayMessage) error {
 	req.Header.Add("x-stackdriver-apikey", sdc.ApiKey)
 
 	res, err := client.Do(req)
-
-	// Close here to protect against redirection failures where both res and err may be non-nil.
-	if res != nil {
-		defer res.Body.Close()
-	}
-
 	if err != nil {
 		return err
 	}
+	defer res.Body.Close()
 
 	if (res.StatusCode > 201) || (res.StatusCode < 200) {
 		responseBody, err := ioutil.ReadAll(res.Body)

--- a/custom_metric.go
+++ b/custom_metric.go
@@ -86,6 +86,12 @@ func (sdc *StackdriverClient) Send(gwm GatewayMessage) error {
 	req.Header.Add("x-stackdriver-apikey", sdc.ApiKey)
 
 	res, err := client.Do(req)
+
+	// Close here to protect against redirection failures where both res and err may be non-nil.
+	if res != nil {
+		defer res.Body.Close()
+	}
+
 	if err != nil {
 		return err
 	}

--- a/deploy_event.go
+++ b/deploy_event.go
@@ -61,6 +61,12 @@ func (sdc *StackdriverClient) NewDeployEvent(rid, db, dt, r string) error {
 	req.Header.Add("x-stackdriver-apikey", sdc.ApiKey)
 
 	res, err := client.Do(req)
+
+	// Close here to protect against redirection failures where both res and err may be non-nil.
+	if res != nil {
+		defer res.Body.Close()
+	}
+
 	if err != nil {
 		return err
 	}

--- a/deploy_event.go
+++ b/deploy_event.go
@@ -61,15 +61,10 @@ func (sdc *StackdriverClient) NewDeployEvent(rid, db, dt, r string) error {
 	req.Header.Add("x-stackdriver-apikey", sdc.ApiKey)
 
 	res, err := client.Do(req)
-
-	// Close here to protect against redirection failures where both res and err may be non-nil.
-	if res != nil {
-		defer res.Body.Close()
-	}
-
 	if err != nil {
 		return err
 	}
+	defer res.Body.Close()
 
 	if (res.StatusCode > 200) || (res.StatusCode < 200) {
 		responseBody, err := ioutil.ReadAll(res.Body)


### PR DESCRIPTION
The 3rd party library we use for jumpcloud-events was not properly closing HTTP response bodies.